### PR TITLE
Added WordPress Plugin type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "10up/tenup-sitemaps",
   "description": "10up Sitemaps",
+  "type": "wordpress-plugin",
   "authors": [
     {
       "name": "Taylor Lovett",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc03bd3566956f992a0acab633498630",
+    "content-hash": "149d9a7e5e4ca54b183009d1f070123d",
     "packages": [],
     "packages-dev": [
         {
@@ -80,9 +80,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
+                    "role": "Developer / IT Manager",
                     "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "homepage": "http://www.frenck.nl"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",


### PR DESCRIPTION
### Description of the Change

Added WordPress plugin type; this resolves an issues where the package is installed in the `vendor` directory, and instead adds this to the WP plugins folder.

### Alternate Designs

N/A

### Benefits

The plugin will work

### Possible Drawbacks

N/A

### Verification Process

Ran `composer update`.

This is a simple change and follows the pattern required to define the package as a WordPress plugin for wpackagist.org

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
