### PR TITLE
Prefix sitemap index in `robots.txt` with line feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+- Prefix sitemap index in `robots.txt` with line feed
+
 ## [1.0.3] - 2019-08-12
 ### Fixed
 - No empty urls in sitemap

--- a/includes/core.php
+++ b/includes/core.php
@@ -112,6 +112,6 @@ function disable_canonical_redirects_for_sitemap_xml( $redirect_url, $requested_
  */
 function add_sitemap_robots_txt( $output ) {
 	$url     = site_url( '/sitemap.xml' );
-	$output .= "Sitemap: {$url}\n";
+	$output .= "\nSitemap: {$url}\n";
 	return $output;
 }


### PR DESCRIPTION
### Description of the Change

Prefix sitemap index in robots txt with line feed.

(Same as https://github.com/GoogleChromeLabs/wp-sitemaps/pull/108)

### Benefits

To avoid issues when previous `robots_txt` callback forgets to add `\n` suffix.

### Verification Process


1. Add this filter to break `robots.txt`:

    ```php
    add_filter('robots_txt', function ($output) {
       $output .= 'I am a line without line break';
       return $output;
    }, 9);
    ```

2. Visit `xxx.com/robots.txt`

Before this PR:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
I am a line without line breakSitemap: http://xxx.com/sitemap.xml
```


After this PR:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
I am a line without line break
Sitemap: http://xxx.com/sitemap.xml
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Prefix sitemap index in `robots.txt` with line feed