### PR TITLE
Fix copy/paste error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The plugin indexes all public posts, post type archives, and public taxonomy ter
 
 ## Changelog
 
-A complete listing of all notable changes to Distributor are documented in [CHANGELOG.md](https://github.com/10up/10up-sitemaps/blob/develop/CHANGELOG.md).
+A complete listing of all notable changes to 10up Sitemaps is documented in [CHANGELOG.md](https://github.com/10up/10up-sitemaps/blob/develop/CHANGELOG.md).
 
 ## Like what you see?
 


### PR DESCRIPTION
Replace "Distributor" with "10up Sitemaps"