### PR TITLE
Added conditional check to ensure the 'range' always has a value set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > This is a simple sitemap plugin meant to run at scale. Sitemaps are only updated via WP-CLI. Output is saved in an option for fast reading/displaying on the front end.
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Build Status](https://travis-ci.org/10up/10up-sitemaps.svg?branch=master)](https://travis-ci.org/10up/10up-sitemaps) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.8%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md) 
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Build Status](https://travis-ci.org/10up/10up-sitemaps.svg?branch=master)](https://travis-ci.org/10up/10up-sitemaps) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.9%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md)
 ## Setup/Usage
 
 1. Install the plugin.

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -25,14 +25,11 @@ class Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--type=<range>]
+	 * [--range]
 	 * : Range of posts to include. Either 'all' or a number of months.
 	 *
-	 * [--noprogress]
-	 * : Disables the progress list/estimator
-	 *
 	 * @subcommand generate
-	 * @synopsis [--range] [--noprogress]
+	 * @synopsis [--range]
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -52,6 +52,10 @@ class Command extends WP_CLI_Command {
 
 		$urls_per_page = apply_filters( 'tenup_sitemaps_urls_per_page', 200 );
 
+		if ( ! array_key_exists( 'range', $assoc_args ) ) {
+			$assoc_args['range'] = 'all';
+		}
+
 		$sitemap = new Sitemap( $assoc_args['range'], $urls_per_page, [], $logger );
 
 		$sitemap->build();


### PR DESCRIPTION
### Description of the Change

When the CLI command is run, without the optional `range` param, an error is noted: `PHP Notice:  Undefined index: range`. This 

Closes #14

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I've tested the CLI process on WP 5.8.3 and WP 5.9.1 with this update in place. When I run `wp tenup-sitemaps generate` I no longer see the warning noted.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Fixed - Undefined index: range

### Credits

Props @jamesmorrison
