### PR TITLE
Bump WP tested-up-to, fix license references

### DIFF
--- a/10up-sitemaps.php
+++ b/10up-sitemaps.php
@@ -4,12 +4,12 @@
  * Plugin URI:        https://github.com/10up/10up-sitemaps
  * Description:       Simple sitemaps plugin that performs at scale.
  * Version:           1.0.4
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      7.0
  * Author:            10up
  * Author URI:        https://10up.com
- * License:           GPL v2 or later
- * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * License:           GPL-2.0-or-later
+ * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
  * Text Domain:       tenup-sitemaps
  * Update URI:        https://github.com/10up/10up-sitemaps
  *

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Simple sitemaps plugin that performs at scale. 
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.9%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.6%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md)
 
 ## Overview
 

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "10up/tenup-sitemaps",
   "description": "10up Sitemaps",
   "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Taylor Lovett",

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === 10up Sitemaps ===
 Contributors: 10up, tlovett1, jeffpaul
-Tags: sitemap, wp-cli, cli
-Tested up to: 6.5
-Stable tag: 1.0.4
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         sitemap, wp-cli, cli
+Tested up to: 6.6
+Stable tag:   1.0.4
+License:      GPL-2.0-or-later
+License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 
 Simple sitemaps plugin that performs at scale.
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP tested-up-to version 6.6, the minimum to 6.4, and fixes the license references to `GPL-2.0-or-later`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #23.

### How to test the Change
Preview in GitHub's markdown previewer.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - WordPress "tested up to" version 6.6.
> Changed - WordPress minimum supported version to 6.4.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
