### PR TITLE
Bump: "Tested up to" WP 6.7

### DIFF
--- a/10up-sitemaps.php
+++ b/10up-sitemaps.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/10up-sitemaps
  * Description:       Simple sitemaps plugin that performs at scale.
  * Version:           1.0.4
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP:      7.0
  * Author:            10up
  * Author URI:        https://10up.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![10up Sitemaps](https://github.com/10up/10up-sitemaps/blob/develop/.wordpress-org/banner-1544x500.png)
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.6%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml)
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.7%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml)
 
 > Simple sitemaps plugin that performs at scale.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === 10up Sitemaps ===
 Contributors: 10up, tlovett1, jeffpaul
 Tags:         sitemap, wp-cli, cli
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   1.0.4
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

Updates WordPress "Tested Up To" version to 6.7.

Closes https://github.com/10up/10up-sitemaps/issues/27

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Changed - Bump WordPress "tested up to" version 6.7.

### Credits
@colinswinney 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
