### PR TITLE
Release/1.0.5

### DIFF
--- a/10up-sitemaps.php
+++ b/10up-sitemaps.php
@@ -3,7 +3,7 @@
  * Plugin Name:       10up Sitemaps
  * Plugin URI:        https://github.com/10up/10up-sitemaps
  * Description:       Simple sitemaps plugin that performs at scale.
- * Version:           1.0.4
+ * Version:           1.0.5
  * Requires at least: 6.5
  * Requires PHP:      7.0
  * Author:            10up
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Cannot access page directly' );
 }
 
-define( 'TSM_VERSION', '1.0.4' );
+define( 'TSM_VERSION', '1.0.5' );
 
 /**
  * PSR-4 autoloading

--- a/10up-sitemaps.php
+++ b/10up-sitemaps.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/10up-sitemaps
  * Description:       Simple sitemaps plugin that performs at scale.
  * Version:           1.0.5
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.0
  * Author:            10up
  * Author URI:        https://10up.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,57 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+## [1.0.5] - 2025-07-14
+
+**Note that this release bumps the WordPress minimum version from 6.3 to 6.6.**
+
+### Added
+
+- `readme.txt` file (props [@jeffpaul](https://github.com/jeffpaul), [@Sidsector9](https://github.com/Sidsector9) via [#19](https://github.com/10up/10up-sitemaps/pull/19)).
+
+### Changed
+
+- Bump WordPress "tested up to" version 6.8 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28)).
+- Bump WordPress minimum supported version to 6.6 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28)).
+
+### Developer
+
+- Add WordPress.org plugin assets (props [@jeffpaul](https://github.com/jeffpaul), [@dkotter](https://github.com/dkotter) via [#18](https://github.com/10up/10up-sitemaps/pull/18)).
+- Replaced `lee-dohm/no-response` with `actions/stale` to help with closing no-response/stale issues (props [@jeffpaul](https://github.com/jeffpaul), [@dkotter](https://github.com/dkotter) via [#21](https://github.com/10up/10up-sitemaps/pull/21)).
+- Update `README.md` file to include the plugin banner image and badges (props [@jeffpaul](https://github.com/jeffpaul), [@dkotter](https://github.com/dkotter) via [#26](https://github.com/10up/10up-sitemaps/pull/26)).
+
 ## [1.0.4] - 2023-09-07
+
 ### Fixed
+
 - Prefix sitemap index in `robots.txt` with line feed.
 
 ## [1.0.3] - 2019-08-12
+
 ### Fixed
+
 - No empty urls in sitemap.
 
 ## [1.0.2] - 2019-08-05
+
 ### Added
+
 - WordPress Plugin type.
 
 ## [1.0.1] - 2019-08-05
+
 ### Changed
+
 - Package name.
 
 ### Fixed
+
 - Log url properly.
 
 ## [1.0.0] - 2019-08-01
+
 ### Added
+
 - Homepage and post type archive.
 - Progress estimator.
 - `stop_the_insanity()` calls.
@@ -32,15 +62,19 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Page link filter.
 
 ### Removed
+
 - `changefrew` and `priority` from template.
 
 ## [0.1.0] - 2019-06-26
+
 ### Added
+
 - Initial plugin release! 🎉
 - Sitemaps are only updated via WP-CLI.
 - Output is saved in an option for fast reading/displaying on the front end.
 
 [Unreleased]: https://github.com/10up/10up-sitemaps/compare/1.0.3...trunk
+[1.0.5]: https://github.com/10up/10up-sitemaps/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/10up/10up-sitemaps/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/10up/10up-sitemaps/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/10up/10up-sitemaps/compare/1.0.1...1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ### Changed
 
-- Bump WordPress "tested up to" version 6.8 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28)).
-- Bump WordPress minimum supported version to 6.6 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28)).
+- Bump WordPress "tested up to" version 6.8 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28), [#31](https://github.com/10up/10up-sitemaps/pull/31)).
+- Bump WordPress minimum supported version to 6.6 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28), [#31](https://github.com/10up/10up-sitemaps/pull/31)).
 
 ### Developer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Sitemaps are only updated via WP-CLI.
 - Output is saved in an option for fast reading/displaying on the front end.
 
-[Unreleased]: https://github.com/10up/10up-sitemaps/compare/1.0.3...trunk
+[Unreleased]: https://github.com/10up/10up-sitemaps/compare/trunk...develop
 [1.0.5]: https://github.com/10up/10up-sitemaps/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/10up/10up-sitemaps/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/10up/10up-sitemaps/compare/1.0.2...1.0.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,12 @@ The `develop` branch is the development branch which means it contains the next 
 ## Release instructions
 
 1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-2. Version bump: Bump the version number in `10up-sitemaps.php`, `readme.txt`, and any other relevant files if it does not already reflect the version being released.
+2. Version bump: Bump the version number in `10up-sitemaps.php` and `readme.txt` if it does not already reflect the version being released. Update both the plugin "Version:" property and the plugin `TSM_VERSION` constant in `10up-sitemaps.php`.
 3. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`.
 4. Props: update `CREDITS.md` file with any new contributors, and confirm maintainers are accurate.
 5. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes` or `.distignore`.
-6. Readme updates: Make any other readme changes as necessary. `CHANGELOG.md` and `README.md` are geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.
-7. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `trunk`, ensuring you pull the most recent changes into `develop` first (`git checkout develop && git pull origin develop && git checkout trunk && git merge --no-ff develop`). `trunk` contains the stable development version.
+6. Readme updates: Make any other readme changes as necessary. `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.
+7. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `trunk`, ensuring you pull the most recent changes into `develop` first (`git checkout develop && git pull origin develop && git checkout trunk && git pull origin trunk && git merge --no-ff develop`). `trunk` contains the stable development version.
 8. Push: Push your `trunk` branch to GitHub (e.g. `git push origin trunk`).
 9. Compare `trunk` to `develop` to ensure no additional changes were missed. Visit https://github.com/10up/10up-sitemaps/compare/trunk...develop
 10. Test the pre-release ZIP locally by downloading it from the **Build release zip** action artifact and installing it locally. Ensure this zip has all the files we expect, that it installs and activates correctly and that all basic functionality is working.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -12,7 +12,7 @@ The following individuals are responsible for curating the list of issues, respo
 
 Thank you to all the people who have already contributed to this repository via bug reports, code, design, ideas, project management, translation, testing, etc.
 
-[Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Pete Nelson (@petenelson)](https://github.com/petenelson), [James Morrison (@jamesmorrison)](https://github.com/jamesmorrison), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Tang Rufus (@TangRufus)](https://github.com/TangRufus), [Viktor Szépe (@szepeviktor)](https://github.com/szepeviktor), [Brandon Berg (@BBerg10up)](https://github.com/BBerg10up), [Barry Ceelen (@barryceelen)](https://github.com/barryceelen), [Sudip Dadhaniya (@sudip-10up)](https://github.com/sudip-10up), [Ravinder Kumar (@ravinderk)](https://github.com/ravinderk).
+[Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Pete Nelson (@petenelson)](https://github.com/petenelson), [James Morrison (@jamesmorrison)](https://github.com/jamesmorrison), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Tang Rufus (@TangRufus)](https://github.com/TangRufus), [Viktor Szépe (@szepeviktor)](https://github.com/szepeviktor), [Brandon Berg (@BBerg10up)](https://github.com/BBerg10up), [Barry Ceelen (@barryceelen)](https://github.com/barryceelen), [Sudip Dadhaniya (@sudip-10up)](https://github.com/sudip-10up), [Ravinder Kumar (@ravinderk)](https://github.com/ravinderk), [Siddharth Thevaril (@Sidsector9)](https://github.com/Sidsector9), [Sudip Dadhaniya (@sudip-md)](https://github.com/sudip-md), [Colin Swinney (@colinswinney)](https://github.com/colinswinney), [Darin Kotter (@dkotter)](https://github.com/dkotter).
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![10up Sitemaps](https://github.com/10up/10up-sitemaps/blob/develop/.wordpress-org/banner-1544x500.png)
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.7%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml)
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.8%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/10up-sitemaps.svg)](https://github.com/10up/10up-sitemaps/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/10up-sitemaps/actions/workflows/dependency-review.yml)
 
 > Simple sitemaps plugin that performs at scale.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === 10up Sitemaps ===
 Contributors: 10up, tlovett1, jeffpaul
 Tags:         sitemap, wp-cli, cli
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.0.5
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
@@ -23,6 +23,11 @@ You can pass `--range` to the `generate` command to only index content within a 
 The plugin indexes all public posts, post type archives, and public taxonomy term archives. For posts, images are parsed and included. Translated content needs to be manually filtered in via `tenup_sitemaps_term_translations`.
 
 == Changelog ==
+
+= 1.0.5 - 2025-07-14 =
+* **Added:** `readme.txt` file.
+* **Changed:** Bump WordPress "tested up to" version 6.8.
+* **Changed:** Bump WordPress minimum supported version to 6.6.
 
 = 1.0.4 - 2023-09-07 =
 * **Fixed:** Prefix sitemap index in `robots.txt` with line feed.
@@ -49,3 +54,9 @@ The plugin indexes all public posts, post type archives, and public taxonomy ter
 * **Added:** Initial plugin release! 🎉
 * **Added:** Sitemaps are only updated via WP-CLI.
 * **Added:** Output is saved in an option for fast reading/displaying on the front end.
+
+== Upgrade Notice ==
+
+= 1.0.5 =
+
+Note that this release bumps the WordPress minimum version from 6.3 to 6.6.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: 10up, tlovett1, jeffpaul
 Tags:         sitemap, wp-cli, cli
 Tested up to: 6.7
-Stable tag:   1.0.4
+Stable tag:   1.0.5
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,9 +25,9 @@ The plugin indexes all public posts, post type archives, and public taxonomy ter
 == Changelog ==
 
 = 1.0.5 - 2025-07-14 =
-* **Added:** `readme.txt` file.
-* **Changed:** Bump WordPress "tested up to" version 6.8.
-* **Changed:** Bump WordPress minimum supported version to 6.6.
+* **Added:** `readme.txt` file (props [@jeffpaul](https://github.com/jeffpaul), [@Sidsector9](https://github.com/Sidsector9) via [#19](https://github.com/10up/10up-sitemaps/pull/19)).
+* **Changed:** Bump WordPress "tested up to" version 6.8 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28), [#31](https://github.com/10up/10up-sitemaps/pull/31)).
+* **Changed:** Bump WordPress minimum supported version to 6.6 (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-md](https://github.com/sudip-md), [@colinswinney](https://github.com/colinswinney), [@dkotter](https://github.com/dkotter) via [#22](https://github.com/10up/10up-sitemaps/pull/22), [#24](https://github.com/10up/10up-sitemaps/pull/24), [#28](https://github.com/10up/10up-sitemaps/pull/28), [#31](https://github.com/10up/10up-sitemaps/pull/31)).
 
 = 1.0.4 - 2023-09-07 =
 * **Fixed:** Prefix sitemap index in `robots.txt` with line feed.


### PR DESCRIPTION
### Description of the Change

Version bump and prep for the 1.0.5 release. Also bumps the `Tested up to` WordPress version to 6.8 and minimum version to 6.6.

Closes #30 

### How to test the Change

Verify all file changes look accurate and tests pass

### Changelog Entry

n/a

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
